### PR TITLE
feat: add LinkPopover component for improved link management

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain } from 'electron';
+import { app, BrowserWindow, ipcMain, shell } from 'electron';
 import path from 'node:path';
 import started from 'electron-squirrel-startup';
 import * as fileHandlers from './fileSystem/fileHandlers';
@@ -50,6 +50,11 @@ const createWindow = () => {
 
 // Register IPC handlers for file system operations
 function registerIpcHandlers() {
+  // Shell operations
+  ipcMain.handle('shell:openExternal', async (_event, url: string) => {
+    await shell.openExternal(url);
+  });
+
   // File operations
   ipcMain.handle('fs:readFile', async (_event, filePath: string) => {
     return await fileHandlers.readFile(filePath);

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -22,6 +22,9 @@ import type {
 const electronAPI: IElectronAPI = {
   platform: process.platform,
 
+  openExternal: (url: string): Promise<void> =>
+    ipcRenderer.invoke('shell:openExternal', url),
+
   fileSystem: {
     // File operations
     readFile: (filePath: string): Promise<FileContent> =>

--- a/src/renderer/components/Editor/EditorComponent.tsx
+++ b/src/renderer/components/Editor/EditorComponent.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { EditorContent } from '@tiptap/react';
 import { useEditor } from '../../hooks/useEditor';
 import { EditorToolbar } from './EditorToolbar';
+import { LinkPopover } from './LinkPopover';
 
 interface EditorComponentProps {
   content?: string;
@@ -19,6 +20,7 @@ export const EditorComponent = ({
   editable = true,
 }: EditorComponentProps) => {
   const [, forceUpdate] = useState({});
+  const [isLinkPopoverOpen, setIsLinkPopoverOpen] = useState(false);
 
   const editor = useEditor({
     content,
@@ -35,13 +37,10 @@ export const EditorComponent = ({
     if (!editor) return;
 
     const handleKeyDown = (e: KeyboardEvent) => {
-      // Cmd/Ctrl + K for link
+      // Cmd/Ctrl + K for link popover
       if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
         e.preventDefault();
-        const url = window.prompt('Enter URL:');
-        if (url) {
-          editor.chain().focus().setLink({ href: url }).run();
-        }
+        setIsLinkPopoverOpen(true);
       }
 
       // Cmd/Ctrl + E for inline code (alternative)
@@ -57,10 +56,15 @@ export const EditorComponent = ({
 
   return (
     <div className="flex h-full flex-col bg-base-100">
-      <EditorToolbar editor={editor} />
+      <EditorToolbar editor={editor} onOpenLinkPopover={() => setIsLinkPopoverOpen(true)} />
       <div className="flex-1 overflow-auto">
         <EditorContent editor={editor} />
       </div>
+      <LinkPopover
+        editor={editor}
+        isOpen={isLinkPopoverOpen}
+        onClose={() => setIsLinkPopoverOpen(false)}
+      />
     </div>
   );
 };

--- a/src/renderer/components/Editor/EditorToolbar.tsx
+++ b/src/renderer/components/Editor/EditorToolbar.tsx
@@ -18,19 +18,13 @@ import {
 
 interface EditorToolbarProps {
   editor: Editor | null;
+  onOpenLinkPopover: () => void;
 }
 
-export const EditorToolbar = ({ editor }: EditorToolbarProps) => {
+export const EditorToolbar = ({ editor, onOpenLinkPopover }: EditorToolbarProps) => {
   if (!editor) {
     return null;
   }
-
-  const addLink = () => {
-    const url = window.prompt('Enter URL:');
-    if (url) {
-      editor.chain().focus().setLink({ href: url }).run();
-    }
-  };
 
   const addImage = () => {
     const url = window.prompt('Enter image URL:');
@@ -189,7 +183,7 @@ export const EditorToolbar = ({ editor }: EditorToolbarProps) => {
         {/* Links & Images */}
         <div className="join">
           <ToolbarButton
-            onClick={addLink}
+            onClick={onOpenLinkPopover}
             active={editor.isActive('link')}
             title="Add Link (Cmd+K)"
           >

--- a/src/renderer/components/Editor/LinkPopover.tsx
+++ b/src/renderer/components/Editor/LinkPopover.tsx
@@ -1,0 +1,173 @@
+import { useState, useEffect, useRef } from 'react';
+import { Editor } from '@tiptap/react';
+import { Link as LinkIcon, ExternalLink, Trash2 } from 'lucide-react';
+
+interface LinkPopoverProps {
+  editor: Editor | null;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export const LinkPopover = ({ editor, isOpen, onClose }: LinkPopoverProps) => {
+  const [url, setUrl] = useState('');
+  const [position, setPosition] = useState({ top: 0, left: 0 });
+  const inputRef = useRef<HTMLInputElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  // Get current link URL if cursor is on a link
+  useEffect(() => {
+    if (!editor || !isOpen) return;
+
+    const linkAttrs = editor.getAttributes('link');
+    setUrl(linkAttrs.href || '');
+  }, [editor, isOpen]);
+
+  // Calculate position based on selection
+  useEffect(() => {
+    if (!editor || !isOpen) return;
+
+    const { from } = editor.state.selection;
+    const domNode = editor.view.domAtPos(from);
+    const rect = (domNode.node as Element).getBoundingClientRect?.() ||
+                 editor.view.dom.getBoundingClientRect();
+
+    // Position popover below the selection
+    setPosition({
+      top: rect.bottom + window.scrollY + 8,
+      left: rect.left + window.scrollX,
+    });
+
+    // Focus input after a short delay to ensure it's rendered
+    setTimeout(() => inputRef.current?.focus(), 50);
+  }, [editor, isOpen]);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleClickOutside = (e: MouseEvent) => {
+      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [isOpen, onClose]);
+
+  // Close on Escape key
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [isOpen, onClose]);
+
+  if (!editor || !isOpen) {
+    return null;
+  }
+
+  const currentLink = editor.getAttributes('link').href;
+
+  const handleSetLink = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!url.trim()) {
+      return;
+    }
+
+    // Add protocol if missing
+    let finalUrl = url.trim();
+    if (!finalUrl.match(/^https?:\/\//i) && !finalUrl.match(/^mailto:/i)) {
+      finalUrl = 'https://' + finalUrl;
+    }
+
+    editor
+      .chain()
+      .focus()
+      .extendMarkRange('link')
+      .setLink({ href: finalUrl })
+      .run();
+
+    onClose();
+  };
+
+  const handleRemoveLink = () => {
+    editor.chain().focus().unsetLink().run();
+    onClose();
+  };
+
+  const handleOpenLink = () => {
+    if (currentLink) {
+      window.electronAPI.openExternal(currentLink);
+    }
+  };
+
+  return (
+    <div
+      ref={popoverRef}
+      className="fixed z-50 bg-base-100 border border-base-300 rounded-lg shadow-lg p-3 min-w-80"
+      style={{
+        top: `${position.top}px`,
+        left: `${position.left}px`,
+      }}
+    >
+      <form onSubmit={handleSetLink} className="flex flex-col gap-2">
+        <div className="flex items-center gap-2">
+          <LinkIcon className="h-4 w-4 text-base-content/50" />
+          <input
+            ref={inputRef}
+            type="text"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            placeholder="Enter URL..."
+            className="input input-sm input-bordered flex-1"
+          />
+        </div>
+
+        <div className="flex gap-2 justify-end">
+          {currentLink && (
+            <>
+              <button
+                type="button"
+                onClick={handleOpenLink}
+                className="btn btn-sm btn-ghost"
+                title="Open link in browser"
+              >
+                <ExternalLink className="h-4 w-4" />
+              </button>
+              <button
+                type="button"
+                onClick={handleRemoveLink}
+                className="btn btn-sm btn-ghost text-error"
+                title="Remove link"
+              >
+                <Trash2 className="h-4 w-4" />
+              </button>
+            </>
+          )}
+          <button
+            type="button"
+            onClick={onClose}
+            className="btn btn-sm btn-ghost"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            className="btn btn-sm btn-primary"
+            disabled={!url.trim()}
+          >
+            {currentLink ? 'Update' : 'Set Link'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -14,6 +14,9 @@ export interface IElectronAPI {
   // Platform info
   platform: NodeJS.Platform;
 
+  // Shell operations
+  openExternal: (url: string) => Promise<void>;
+
   // File operations
   fileSystem: {
     // File operations


### PR DESCRIPTION
## Summary

Replaces the basic `window.prompt()` link creation with a custom LinkPopover component that provides a modern, user-friendly interface for creating, editing, and removing links in the TipTap editor.

### What's Changed

- **New `LinkPopover` component** - A floating popover UI for link management
  - Create links from selected text
  - Edit existing links (click link button when cursor is on a link)
  - Remove links with trash button
  - Open links in external browser
  - Auto-adds `https://` protocol if missing
  - Click outside or press Escape to close

- **Updated keyboard shortcut** - Cmd+K now opens the popover instead of browser prompt

- **Added IPC method** - `openExternal` to open links in the system browser

### Technical Details

**Files Modified:**
- `src/renderer/components/Editor/LinkPopover.tsx` (new) - Custom popover component
- `src/renderer/components/Editor/EditorComponent.tsx` - Integrated popover with Cmd+K shortcut
- `src/renderer/components/Editor/EditorToolbar.tsx` - Link button triggers popover
- `src/main/main.ts` - Added `shell.openExternal` IPC handler
- `src/main/preload.ts` - Exposed `openExternal` method
- `src/shared/types.ts` - Added `openExternal` to API types

### UI/UX Improvements

✅ Better user experience than browser's native prompt  
✅ Visual feedback with active link state  
✅ Easy link editing and removal  
✅ Keyboard accessible (Cmd+K, Escape)  
✅ Styled with DaisyUI to match app theme  

### Test Plan

- [x] Cmd+K creates link from selected text
- [x] Link button in toolbar opens popover
- [x] Can edit existing links by clicking link button when cursor is on a link
- [x] Can remove links with trash button
- [x] External link button opens URL in browser
- [x] Auto-adds https:// protocol when missing
- [x] TypeScript compilation passes with no errors
- [x] App launches successfully