### PR TITLE
refactor: remove redundant conditional check in EditorComponent

### DIFF
--- a/src/renderer/components/Editor/EditorComponent.tsx
+++ b/src/renderer/components/Editor/EditorComponent.tsx
@@ -64,12 +64,9 @@ export const EditorComponent = ({
     const hasContentChanged = content !== prevContentRef.current;
 
     if (editor && content && (isViewModeTransition || (viewMode === 'wysiwyg' && hasContentChanged))) {
-      // Only update if we're transitioning or content actually changed
-      if (isViewModeTransition || hasContentChanged) {
-        // Convert markdown to TipTap JSON and set in editor
-        const json = markdownToJSON(content);
-        editor.commands.setContent(json);
-      }
+      // Convert markdown to TipTap JSON and set in editor
+      const json = markdownToJSON(content);
+      editor.commands.setContent(json);
     }
 
     prevViewModeRef.current = viewMode;


### PR DESCRIPTION
## Summary
- Removed nested redundant condition in `EditorComponent.tsx` content sync useEffect
- The outer condition already validates when updates are needed, making the inner check unnecessary
- Improves code clarity without changing behavior

## Details
The useEffect at line 62-77 had a redundant nested conditional:
- **Outer check:** `(isViewModeTransition || (viewMode === 'wysiwyg' && hasContentChanged))`
- **Inner check:** `(isViewModeTransition || hasContentChanged)` ❌ Redundant

When the outer condition is true, the inner condition is guaranteed to be true, making it unnecessary.

## Test plan
- [ ] Verify WYSIWYG ↔ Markdown mode switching still works
- [ ] Verify content updates properly when switching from markdown to WYSIWYG
- [ ] Verify no infinite re-render loops occur
- [ ] Run existing editor tests