### PR TITLE
Add Conductor workspace setup script with bun support

### DIFF
--- a/.conductor/setup.sh
+++ b/.conductor/setup.sh
@@ -14,11 +14,7 @@ echo "✅ Bun found: $(bun --version)"
 
 # Install dependencies
 echo "📦 Installing dependencies..."
-bun install
-
-# Verify installation
-echo "🔍 Verifying installation..."
-if [ ! -d "node_modules" ]; then
+if ! bun install; then
     echo "❌ Dependencies installation failed"
     exit 1
 fi
@@ -33,3 +29,4 @@ echo "   bun test:coverage  - Run tests with coverage"
 echo "   bun run lint       - Lint code"
 echo "   bun package        - Package application"
 echo "   bun make           - Create distributable installers"
+echo "   bun publish        - Publish application"

--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,6 @@ typings/
 
 # Electron-Forge
 out/
+
+# Conductor workspace directories (keep .conductor/setup.sh but ignore workspaces)
+.conductor/*/


### PR DESCRIPTION
## Summary
- Added setup script for Conductor workspaces (`.conductor/setup.sh`)
- Uses **bun** instead of npm for dependency management
- Includes verification checks and helpful command documentation

## Changes
- New executable setup script that:
  - Checks for bun installation
  - Installs dependencies via `bun install`
  - Verifies successful installation
  - Displays available development commands

## Test plan
- [ ] Run `.conductor/setup.sh` in a fresh Conductor workspace
- [ ] Verify bun installation check works
- [ ] Verify dependencies install correctly
- [ ] Verify all listed commands work as expected